### PR TITLE
Add MLM analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ The library offers the following classes:
             * `ConstantWashover`: accepts a timedelta parameter and removes the data when we switch from A to B for the timedelta interval.
 * Regarding analysis:
     * `GeeExperimentAnalysis`: to run GEE analysis on the results of a clustered design
+    * `MLMExperimentAnalysis`: to run Mixed Linear Model analysis on the results of a clustered design
     * `TTestClusteredAnalysis`: to run a t-test on aggregated data for clusters
     * `PairedTTestClusteredAnalysis`: to run a paired t-test on aggregated data for clusters
     * `ClusteredOLSAnalysis`: to run OLS analysis on the results of a clustered design

--- a/cluster_experiments/__init__.py
+++ b/cluster_experiments/__init__.py
@@ -3,6 +3,7 @@ from cluster_experiments.experiment_analysis import (
     ClusteredOLSAnalysis,
     ExperimentAnalysis,
     GeeExperimentAnalysis,
+    MLMExperimentAnalysis,
     OLSAnalysis,
     PairedTTestClusteredAnalysis,
     TTestClusteredAnalysis,
@@ -51,4 +52,5 @@ __all__ = [
     "EmptyWashover",
     "ConstantWashover",
     "Washover",
+    "MLMExperimentAnalysis",
 ]

--- a/cluster_experiments/experiment_analysis.py
+++ b/cluster_experiments/experiment_analysis.py
@@ -634,3 +634,13 @@ class MLMExperimentAnalysis(ExperimentAnalysis):
         results_mlm = self.fit_mlm(df)
         # negative sign, as we use the treatment as reference (instead of the baseline)
         return -results_mlm.params[self.mlm_treatment_label]
+
+    def get_pvalue(self, df: pd.DataFrame) -> float:
+        """Returns the p-value of the analysis
+
+        Arguments:
+            df: dataframe containing the data to analyze
+        """
+        df = df.copy()
+        self._data_checks(df=df)
+        return self.analysis_pvalue(df)

--- a/cluster_experiments/experiment_analysis.py
+++ b/cluster_experiments/experiment_analysis.py
@@ -513,3 +513,98 @@ class OLSAnalysis(ExperimentAnalysis):
             treatment=config.treatment,
             covariates=config.covariates,
         )
+
+
+class MLMExperimentAnalysis(ExperimentAnalysis):
+    """
+    Class to run Mixed Linear Models clustered analysis
+
+    Arguments:
+        cluster_cols: list of columns to use as clusters
+        target_col: name of the column containing the variable to measure
+        treatment_col: name of the column containing the treatment variable
+        treatment: name of the treatment to use as the treated group
+        covariates: list of columns to use as covariates
+
+    Usage:
+
+    ```python
+    from cluster_experiments.experiment_analysis import MLMExperimentAnalysis
+    import pandas as pd
+
+    df = pd.DataFrame({
+        'x': [1, 2, 3, 0, 0, 1],
+        'treatment': ["A"] * 3 + ["B"] * 3,
+        'cluster': [1] * 6,
+    })
+
+    MLMExperimentAnalysis(
+        cluster_cols=['cluster'],
+        target_col='x',
+    ).get_pvalue(df)
+    ```
+    """
+
+    def __init__(
+        self,
+        cluster_cols: List[str],
+        target_col: str = "target",
+        treatment_col: str = "treatment",
+        treatment: str = "B",
+        covariates: Optional[List[str]] = None,
+    ):
+        super().__init__(
+            target_col=target_col,
+            treatment_col=treatment_col,
+            cluster_cols=cluster_cols,
+            treatment=treatment,
+            covariates=covariates,
+        )
+        # the specification with C() ensures consistent ordering of treatment and non-treatment in the model
+        self.mlm_treatment_spec = (
+            f"C({self.treatment_col}, Treatment(reference='{self.treatment}'))"
+        )
+        self.mlm_treatment_label = None
+        self.formula = f"{self.target_col} ~ {self.mlm_treatment_spec}"
+        if self.covariates:
+            self.formula = f"{self.formula} + {' + '.join(self.covariates)}"
+
+        self.re_formula = None
+        self.vc_formula = None
+
+    def fit_mlm(self, df: pd.DataFrame) -> sm.MixedLM:
+        """Returns the fitted MLM model"""
+        self.mlm_treatment_label = (
+            f"{self.mlm_treatment_spec}[T.{self._get_non_treatment_label(df)}]"
+        )
+        return sm.MixedLM.from_formula(
+            formula=self.formula,
+            data=df,
+            groups=self._get_cluster_column(df),
+            re_formula=self.re_formula,
+            vc_formula=self.vc_formula,
+        ).fit()
+
+    def _get_non_treatment_label(self, df):
+        return (set(df[self.treatment_col]) - set([self.treatment])).pop()
+
+    def analysis_pvalue(self, df: pd.DataFrame, verbose: bool = False) -> float:
+        """Returns the p-value of the analysis
+        Arguments:
+            df: dataframe containing the data to analyze
+            verbose (Optional): bool, prints the regression summary if True
+        """
+        results_mlm = self.fit_mlm(df)
+        if verbose:
+            print(results_mlm.summary())
+        return results_mlm.pvalues[self.mlm_treatment_label]
+
+    def analysis_point_estimate(self, df: pd.DataFrame, verbose: bool = False) -> float:
+        """Returns the point estimate of the analysis
+        Arguments:
+            df: dataframe containing the data to analyze
+            verbose (Optional): bool, prints the regression summary if True
+        """
+        results_mlm = self.fit_mlm(df)
+        # negative sign, as we use the treatment as reference (instead of the baseline)
+        return -results_mlm.params[self.mlm_treatment_label]

--- a/cluster_experiments/power_config.py
+++ b/cluster_experiments/power_config.py
@@ -6,6 +6,7 @@ from cluster_experiments.cupac import EmptyRegressor, TargetAggregation
 from cluster_experiments.experiment_analysis import (
     ClusteredOLSAnalysis,
     GeeExperimentAnalysis,
+    MLMExperimentAnalysis,
     OLSAnalysis,
     PairedTTestClusteredAnalysis,
     TTestClusteredAnalysis,
@@ -132,6 +133,7 @@ analysis_mapping = {
     "ols_clustered": ClusteredOLSAnalysis,
     "ttest_clustered": TTestClusteredAnalysis,
     "paired_ttest_clustered": PairedTTestClusteredAnalysis,
+    "mlm": MLMExperimentAnalysis,
 }
 
 cupac_model_mapping = {"": EmptyRegressor, "mean_cupac_model": TargetAggregation}

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ dev_packages = test_packages + util_packages + docs_packages
 
 setup(
     name="cluster_experiments",
-    version="0.6.3",
+    version="0.6.4",
     packages=find_packages(),
     extras_require={
         "dev": dev_packages,

--- a/tests/analysis/test_analysis.py
+++ b/tests/analysis/test_analysis.py
@@ -5,6 +5,7 @@ import pytest
 from cluster_experiments.experiment_analysis import (
     ExperimentAnalysis,
     GeeExperimentAnalysis,
+    MLMExperimentAnalysis,
     PairedTTestClusteredAnalysis,
     TTestClusteredAnalysis,
 )
@@ -49,6 +50,16 @@ def test_get_pvalue():
         cluster_cols=["cluster", "date"],
     )
     assert analyser.get_pvalue(analysis_df_full) >= 0
+
+
+def test_mlm_analysis(analysis_df_diff):
+    analyser = MLMExperimentAnalysis(
+        cluster_cols=["cluster", "date"],
+    )
+    p_value = analyser.get_pvalue(analysis_df_diff)
+    point_estimate = analyser.analysis_point_estimate(analysis_df_diff)
+    assert np.isclose(p_value, 0)
+    assert np.isclose(point_estimate, 0.1)
 
 
 def test_ttest(analysis_df_diff):

--- a/tests/analysis/test_analysis.py
+++ b/tests/analysis/test_analysis.py
@@ -57,7 +57,7 @@ def test_mlm_analysis(analysis_df_diff):
         cluster_cols=["cluster", "date"],
     )
     p_value = analyser.get_pvalue(analysis_df_diff)
-    point_estimate = analyser.analysis_point_estimate(analysis_df_diff)
+    point_estimate = analyser.get_point_estimate(analysis_df_diff)
     assert np.isclose(p_value, 0)
     assert np.isclose(point_estimate, 0.1)
 

--- a/tests/analysis/test_analysis.py
+++ b/tests/analysis/test_analysis.py
@@ -56,10 +56,13 @@ def test_mlm_analysis(analysis_df_diff):
     analyser = MLMExperimentAnalysis(
         cluster_cols=["cluster", "date"],
     )
+    # Changing just one observation so we have a p value
+    analysis_df_diff.loc[1, "target"] = 0.00001
+
     p_value = analyser.get_pvalue(analysis_df_diff)
     point_estimate = analyser.get_point_estimate(analysis_df_diff)
-    assert np.isclose(p_value, 0)
-    assert np.isclose(point_estimate, 0.1)
+    assert np.isclose(p_value, 0, atol=1e-5)
+    assert np.isclose(point_estimate, 0.1, atol=1e-5)
 
 
 def test_ttest(analysis_df_diff):

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -12,6 +12,7 @@ from cluster_experiments import (
     EmptyWashover,
     ExperimentAnalysis,
     GeeExperimentAnalysis,
+    MLMExperimentAnalysis,
     NonClusteredSplitter,
     OLSAnalysis,
     PairedTTestClusteredAnalysis,
@@ -53,6 +54,7 @@ all_objects = [
     BalancedSwitchbackSplitter,
     StratifiedSwitchbackSplitter,
     SwitchbackSplitter,
+    MLMExperimentAnalysis,
 ]
 
 


### PR DESCRIPTION
Add Mixed Linear Model experiment analysis

Note: It could be a good idea to have the `fit` method in the interface also for other statsmodels analyses. This could also allow for avoiding `fit` to be called multiple times when separately executing `analysis_point_estimate` and `get_pvalue`. But I decided not to touch the interface in this PR.