### PR TITLE
fix: binary perturbator raise

### DIFF
--- a/cluster_experiments/perturbator.py
+++ b/cluster_experiments/perturbator.py
@@ -107,7 +107,7 @@ class BinaryPerturbator(Perturbator):
     def _data_checks(self, df: pd.DataFrame, average_effect: float) -> None:
         """Check that outcome is indeed binary, and average effect is in (-1, 1)"""
 
-        if set(df[self.target_col].unique()) != {0, 1}:
+        if set(df[self.target_col].unique()) - {0, 1}:
             raise ValueError(
                 f"Target column must be binary, found {set(df[self.target_col].unique())}"
             )


### PR DESCRIPTION
Only raise when there are values in outcome different than 0 or 1