### PR TITLE
Pb/add relative stochastic perturbators

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,8 +148,9 @@ The library offers the following classes:
     * `PowerAnalysis`: to run power analysis on a clustered/switchback design
     * `UniformPerturbator`: to artificially perturb treated group with uniform perturbations
     * `BinaryPerturbator`: to artificially perturb treated group for binary outcomes
-    *
+    * `RelativePositivePerturbator`: to artificially perturb treated group with relative positive perturbations
     * `StochasticPerturbator`: to artificially perturb treated group with normal distribution perturbations
+    * `StochasticRelativePositivePerturbator`: to artificially perturb treated group with relative positive beta distribution perturbations
 * Regarding splitting data:
     * `ClusteredSplitter`: to split data based on clusters
     * `BalancedClusteredSplitter`: to split data based on clusters in a balanced way

--- a/README.md
+++ b/README.md
@@ -148,7 +148,8 @@ The library offers the following classes:
     * `PowerAnalysis`: to run power analysis on a clustered/switchback design
     * `UniformPerturbator`: to artificially perturb treated group with uniform perturbations
     * `BinaryPerturbator`: to artificially perturb treated group for binary outcomes
-    * `NormalPerturbator`: to artificially perturb treated group with normal distribution perturbations
+    *
+    * `StochasticPerturbator`: to artificially perturb treated group with normal distribution perturbations
 * Regarding splitting data:
     * `ClusteredSplitter`: to split data based on clusters
     * `BalancedClusteredSplitter`: to split data based on clusters in a balanced way

--- a/README.md
+++ b/README.md
@@ -149,8 +149,8 @@ The library offers the following classes:
     * `UniformPerturbator`: to artificially perturb treated group with uniform perturbations
     * `BinaryPerturbator`: to artificially perturb treated group for binary outcomes
     * `RelativePositivePerturbator`: to artificially perturb treated group with relative positive perturbations
-    * `StochasticPerturbator`: to artificially perturb treated group with normal distribution perturbations
-    * `StochasticRelativePositivePerturbator`: to artificially perturb treated group with relative positive beta distribution perturbations
+    * `NormalPerturbator`: to artificially perturb treated group with normal distribution perturbations
+    * `BetaRelativePositivePerturbator`: to artificially perturb treated group with relative positive beta distribution perturbations
 * Regarding splitting data:
     * `ClusteredSplitter`: to split data based on clusters
     * `BalancedClusteredSplitter`: to split data based on clusters in a balanced way

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ The library offers the following classes:
     * `PowerAnalysis`: to run power analysis on a clustered/switchback design
     * `UniformPerturbator`: to artificially perturb treated group with uniform perturbations
     * `BinaryPerturbator`: to artificially perturb treated group for binary outcomes
+    * `NormalPerturbator`: to artificially perturb treated group with normal distribution perturbations
 * Regarding splitting data:
     * `ClusteredSplitter`: to split data based on clusters
     * `BalancedClusteredSplitter`: to split data based on clusters in a balanced way

--- a/cluster_experiments/__init__.py
+++ b/cluster_experiments/__init__.py
@@ -9,11 +9,11 @@ from cluster_experiments.experiment_analysis import (
     TTestClusteredAnalysis,
 )
 from cluster_experiments.perturbator import (
+    BetaRelativePositivePerturbator,
     BinaryPerturbator,
+    NormalPerturbator,
     Perturbator,
     RelativePositivePerturbator,
-    StochasticPerturbator,
-    StochasticRelativePositivePerturbator,
     UniformPerturbator,
 )
 from cluster_experiments.power_analysis import PowerAnalysis
@@ -38,8 +38,8 @@ __all__ = [
     "Perturbator",
     "UniformPerturbator",
     "RelativePositivePerturbator",
-    "StochasticPerturbator",
-    "StochasticRelativePositivePerturbator",
+    "NormalPerturbator",
+    "BetaRelativePositivePerturbator",
     "PowerAnalysis",
     "PowerConfig",
     "EmptyRegressor",

--- a/cluster_experiments/__init__.py
+++ b/cluster_experiments/__init__.py
@@ -9,8 +9,10 @@ from cluster_experiments.experiment_analysis import (
 )
 from cluster_experiments.perturbator import (
     BinaryPerturbator,
-    NormalPerturbator,
     Perturbator,
+    RelativePositivePerturbator,
+    StochasticPerturbator,
+    StochasticRelativePositivePerturbator,
     UniformPerturbator,
 )
 from cluster_experiments.power_analysis import PowerAnalysis
@@ -34,7 +36,9 @@ __all__ = [
     "BinaryPerturbator",
     "Perturbator",
     "UniformPerturbator",
-    "NormalPerturbator",
+    "RelativePositivePerturbator",
+    "StochasticPerturbator",
+    "StochasticRelativePositivePerturbator",
     "PowerAnalysis",
     "PowerConfig",
     "EmptyRegressor",

--- a/cluster_experiments/__init__.py
+++ b/cluster_experiments/__init__.py
@@ -9,6 +9,7 @@ from cluster_experiments.experiment_analysis import (
 )
 from cluster_experiments.perturbator import (
     BinaryPerturbator,
+    NormalPerturbator,
     Perturbator,
     UniformPerturbator,
 )
@@ -33,6 +34,7 @@ __all__ = [
     "BinaryPerturbator",
     "Perturbator",
     "UniformPerturbator",
+    "NormalPerturbator",
     "PowerAnalysis",
     "PowerConfig",
     "EmptyRegressor",

--- a/cluster_experiments/perturbator.py
+++ b/cluster_experiments/perturbator.py
@@ -276,11 +276,11 @@ class StochasticRelativePositivePerturbator(
         """
         Usage:
         ```python
-        from cluster_experiments.perturbator import RelativePositivePerturbator
+        from cluster_experiments.perturbator import StochasticRelativePositivePerturbator
         import pandas as pd
         df = pd.DataFrame({"target": [1, 2, 3], "treatment": ["A", "B", "A"]})
         perturbator = StochasticRelativePositivePerturbator()
-        # Increase target metric by 50%
+        # Increase target metric by 20%
         perturbator.perturbate(df, average_effect=0.2)
         # returns pd.DataFrame({"target": [1, 3, 3], "treatment": ["A", "B", "A"]})
         ```

--- a/cluster_experiments/perturbator.py
+++ b/cluster_experiments/perturbator.py
@@ -200,9 +200,7 @@ class RelativePositivePerturbator(Perturbator):
         df = df.copy().reset_index(drop=True)
         average_effect = self.get_average_effect(average_effect)
         self._assert_multiplicative_effect(df, average_effect)
-        df.loc[df[self.treatment_col] == self.treatment, self.target_col] *= (
-            1 + average_effect
-        )
+        df = self._apply_multiplicative_effect(df, average_effect)
         return df
 
     def _assert_multiplicative_effect(

--- a/cluster_experiments/perturbator.py
+++ b/cluster_experiments/perturbator.py
@@ -18,7 +18,7 @@ class Perturbator(ABC):
 
     Arguments:
         average_effect: The average effect of the treatment
-        target_col: name of the target_col to use as the treated group
+        target_col: name of the target_col to use as the outcome
         treatment_col: The name of the column that contains the treatment
         treatment: name of the treatment to use as the treated group
 
@@ -99,7 +99,7 @@ class NormalPerturbator(Perturbator):
 
     Arguments:
         average_effect (Optional[float], optional): the average effect of the treatment. Defaults to None.
-        target_col (str, optional): name of the target_col to use as the treated group. Defaults to "target".
+        target_col (str, optional): name of the target_col to use as the outcome. Defaults to "target".
         treatment_col (str, optional): the name of the column that contains the treatment. Defaults to "treatment".
         treatment (str, optional): name of the treatment to use as the treated group. Defaults to "B".
         scale (Optional[float], optional): the scale of the effect distribution. Defaults to None.

--- a/cluster_experiments/perturbator.py
+++ b/cluster_experiments/perturbator.py
@@ -208,17 +208,20 @@ class RelativePositivePerturbator(Perturbator):
     def _assert_multiplicative_effect(
         self, df: pd.DataFrame, average_effect: float
     ) -> None:
-        assert -1.0 <= average_effect, (
-            "Simulated effect needs to be bigger than -100% but got "
-            f"{average_effect*100:.1f}%"
-        )
-        frac_zeros = (
-            (df[self.treatment_col] == self.treatment) & (df[self.target_col] == 0)
+        if average_effect < -1.0:
+            raise ValueError(
+                "Simulated effect needs to be bigger than -100%, got "
+                f"{average_effect*100:.1f}%"
+            )
+
+        treatment_zeros = (
+            (df[self.treatment_col] != self.treatment) | (df[self.target_col] == 0)
         ).mean()
-        assert frac_zeros < 1.0, (
-            f"All samples have {self.target_col} = 0 , simulatations can't work with a "
-            f"{self.average_effect} change on that!"
-        )
+        if 1.0 == treatment_zeros:
+            raise ValueError(
+                f"All treatment samples have {self.target_col} = 0, relative effect "
+                f"{average_effect} will have no effect"
+            )
 
     def _apply_multiplicative_effect(
         self, df: pd.DataFrame, effect: Union[float, np.ndarray]

--- a/cluster_experiments/perturbator.py
+++ b/cluster_experiments/perturbator.py
@@ -270,7 +270,7 @@ class StochasticRelativePositivePerturbator(
         df = pd.DataFrame({"target": [1, 2, 3], "treatment": ["A", "B", "A"]})
         perturbator = StochasticRelativePositivePerturbator()
         # Increase target metric by 50%
-        perturbator.perturbate(df, average_effect=0.5)
+        perturbator.perturbate(df, average_effect=0.2)
         # returns pd.DataFrame({"target": [1, 3, 3], "treatment": ["A", "B", "A"]})
         ```
         """

--- a/cluster_experiments/perturbator.py
+++ b/cluster_experiments/perturbator.py
@@ -173,6 +173,17 @@ class StochasticPerturbator(Perturbator):
         ] += sampled_effect
         return df
 
+    @classmethod
+    def from_config(cls, config):
+        """Creates a Perturbator object from a PowerConfig object"""
+        return cls(
+            average_effect=config.average_effect,
+            target_col=config.target_col,
+            treatment_col=config.treatment_col,
+            treatment=config.treatment,
+            scale=config.scale,
+        )
+
 
 class RelativePositivePerturbator(Perturbator):
     """

--- a/cluster_experiments/power_config.py
+++ b/cluster_experiments/power_config.py
@@ -10,7 +10,13 @@ from cluster_experiments.experiment_analysis import (
     PairedTTestClusteredAnalysis,
     TTestClusteredAnalysis,
 )
-from cluster_experiments.perturbator import BinaryPerturbator, UniformPerturbator
+from cluster_experiments.perturbator import (
+    BinaryPerturbator,
+    RelativePositivePerturbator,
+    StochasticPerturbator,
+    StochasticRelativePositivePerturbator,
+    UniformPerturbator,
+)
 from cluster_experiments.random_splitter import (
     BalancedClusteredSplitter,
     BalancedSwitchbackSplitter,
@@ -44,6 +50,7 @@ class PowerConfig:
         time_col: column to use as time in switchback splitter
         covariates: list of columns to use as covariates
         average_effect: average effect to use in the perturbator
+        scale: scale to use in stochastic perturbators
         treatments: list of treatments to use
         alpha: alpha value to use in the power analysis
         agg_col: column to use for aggregation in the CUPAC model
@@ -88,6 +95,7 @@ class PowerConfig:
 
     # Perturbator
     average_effect: Optional[float] = None
+    scale: Optional[float] = None
 
     # Splitter
     treatments: Optional[List[str]] = None
@@ -117,6 +125,9 @@ class PowerConfig:
 perturbator_mapping = {
     "binary": BinaryPerturbator,
     "uniform": UniformPerturbator,
+    "relative_positive_perturbator": RelativePositivePerturbator,
+    "stochastic_perturbator": StochasticPerturbator,
+    "stochastic_relative_positive_perturbator": StochasticRelativePositivePerturbator,
 }
 
 splitter_mapping = {

--- a/cluster_experiments/power_config.py
+++ b/cluster_experiments/power_config.py
@@ -127,8 +127,8 @@ perturbator_mapping = {
     "binary": BinaryPerturbator,
     "uniform": UniformPerturbator,
     "relative_positive_perturbator": RelativePositivePerturbator,
-    "stochastic_perturbator": NormalPerturbator,
-    "stochastic_relative_positive_perturbator": BetaRelativePositivePerturbator,
+    "normal_perturbator": NormalPerturbator,
+    "beta_relative_positive_perturbator": BetaRelativePositivePerturbator,
 }
 
 splitter_mapping = {

--- a/cluster_experiments/power_config.py
+++ b/cluster_experiments/power_config.py
@@ -12,10 +12,10 @@ from cluster_experiments.experiment_analysis import (
     TTestClusteredAnalysis,
 )
 from cluster_experiments.perturbator import (
+    BetaRelativePositivePerturbator,
     BinaryPerturbator,
+    NormalPerturbator,
     RelativePositivePerturbator,
-    StochasticPerturbator,
-    StochasticRelativePositivePerturbator,
     UniformPerturbator,
 )
 from cluster_experiments.random_splitter import (
@@ -127,8 +127,8 @@ perturbator_mapping = {
     "binary": BinaryPerturbator,
     "uniform": UniformPerturbator,
     "relative_positive_perturbator": RelativePositivePerturbator,
-    "stochastic_perturbator": StochasticPerturbator,
-    "stochastic_relative_positive_perturbator": StochasticRelativePositivePerturbator,
+    "stochastic_perturbator": NormalPerturbator,
+    "stochastic_relative_positive_perturbator": BetaRelativePositivePerturbator,
 }
 
 splitter_mapping = {

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ dev_packages = test_packages + util_packages + docs_packages
 
 setup(
     name="cluster_experiments",
-    version="0.7.0",
+    version="0.8.0",
     packages=find_packages(),
     extras_require={
         "dev": dev_packages,

--- a/tests/perturbator/test_perturbator.py
+++ b/tests/perturbator/test_perturbator.py
@@ -70,7 +70,7 @@ def test_uniform_perturbator_perturbate(average_effect, avg_target):
 
 
 @pytest.mark.parametrize("average_effect", [-0.1, 0.1])
-def test_normal_perturbator_perturbate(average_effect):
+def test_stochastic_perturbator_perturbate(average_effect):
     # given
     np.random.seed(24)
     effect = (
@@ -80,9 +80,9 @@ def test_normal_perturbator_perturbate(average_effect):
 
     # when
     np.random.seed(24)
-    normal_perturbator = StochasticPerturbator()
+    stochastic_perturbator = StochasticPerturbator()
     perturbated_values = (
-        normal_perturbator.perturbate(continuous_df, average_effect)
+        stochastic_perturbator.perturbate(continuous_df, average_effect)
         .query("treatment == 'B'")["target"]
         .values
     )
@@ -93,7 +93,7 @@ def test_normal_perturbator_perturbate(average_effect):
 
 
 @pytest.mark.parametrize("average_effect, scale", [(-0.1, 0.02), (0.1, 0.03)])
-def test_normal_scale_provided_is_used(average_effect, scale):
+def test_stochastic_scale_provided_is_used(average_effect, scale):
     # given
     np.random.seed(24)
     effect = (
@@ -103,9 +103,9 @@ def test_normal_scale_provided_is_used(average_effect, scale):
 
     # when
     np.random.seed(24)
-    normal_perturbator = StochasticPerturbator(scale=scale)
+    stochastic_perturbator = StochasticPerturbator(scale=scale)
     perturbated_values = (
-        normal_perturbator.perturbate(continuous_df, average_effect)
+        stochastic_perturbator.perturbate(continuous_df, average_effect)
         .query("treatment == 'B'")["target"]
         .values
     )
@@ -136,7 +136,7 @@ def test_binary_raises_non_binary_target():
         bp.perturbate(binary_df, average_effect=0.05)
 
 
-def test_normal_raises_non_positive_scale():
+def test_stochastic_raises_non_positive_scale():
     _scale = -0.1
     bp = StochasticPerturbator(scale=_scale)
     with pytest.raises(ValueError, match=f"scale must be positive, got {_scale}"):

--- a/tests/perturbator/test_perturbator.py
+++ b/tests/perturbator/test_perturbator.py
@@ -4,7 +4,7 @@ import pytest
 
 from cluster_experiments.perturbator import (
     BinaryPerturbator,
-    NormalPerturbator,
+    StochasticPerturbator,
     UniformPerturbator,
 )
 from tests.examples import binary_df, continuous_df
@@ -80,7 +80,7 @@ def test_normal_perturbator_perturbate(average_effect):
 
     # when
     np.random.seed(24)
-    normal_perturbator = NormalPerturbator()
+    normal_perturbator = StochasticPerturbator()
     perturbated_values = (
         normal_perturbator.perturbate(continuous_df, average_effect)
         .query("treatment == 'B'")["target"]
@@ -103,7 +103,7 @@ def test_normal_scale_provided_is_used(average_effect, scale):
 
     # when
     np.random.seed(24)
-    normal_perturbator = NormalPerturbator(scale=scale)
+    normal_perturbator = StochasticPerturbator(scale=scale)
     perturbated_values = (
         normal_perturbator.perturbate(continuous_df, average_effect)
         .query("treatment == 'B'")["target"]
@@ -138,6 +138,6 @@ def test_binary_raises_non_binary_target():
 
 def test_normal_raises_non_positive_scale():
     _scale = -0.1
-    bp = NormalPerturbator(scale=_scale)
+    bp = StochasticPerturbator(scale=_scale)
     with pytest.raises(ValueError, match=f"scale must be positive, got {_scale}"):
         bp.perturbate(continuous_df, average_effect=0.05)

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -4,6 +4,7 @@ from mktestdocs import check_docstring, check_md_file, get_codeblock_members
 from cluster_experiments import (
     BalancedClusteredSplitter,
     BalancedSwitchbackSplitter,
+    BetaRelativePositivePerturbator,
     BinaryPerturbator,
     ClusteredOLSAnalysis,
     ClusteredSplitter,
@@ -14,6 +15,7 @@ from cluster_experiments import (
     GeeExperimentAnalysis,
     MLMExperimentAnalysis,
     NonClusteredSplitter,
+    NormalPerturbator,
     OLSAnalysis,
     PairedTTestClusteredAnalysis,
     Perturbator,
@@ -21,8 +23,6 @@ from cluster_experiments import (
     PowerConfig,
     RandomSplitter,
     RelativePositivePerturbator,
-    StochasticPerturbator,
-    StochasticRelativePositivePerturbator,
     StratifiedClusteredSplitter,
     StratifiedSwitchbackSplitter,
     SwitchbackSplitter,
@@ -59,8 +59,8 @@ all_objects = [
     SwitchbackSplitter,
     MLMExperimentAnalysis,
     RelativePositivePerturbator,
-    StochasticPerturbator,
-    StochasticRelativePositivePerturbator,
+    NormalPerturbator,
+    BetaRelativePositivePerturbator,
 ]
 
 

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -20,6 +20,9 @@ from cluster_experiments import (
     PowerAnalysis,
     PowerConfig,
     RandomSplitter,
+    RelativePositivePerturbator,
+    StochasticPerturbator,
+    StochasticRelativePositivePerturbator,
     StratifiedClusteredSplitter,
     StratifiedSwitchbackSplitter,
     SwitchbackSplitter,
@@ -55,6 +58,9 @@ all_objects = [
     StratifiedSwitchbackSplitter,
     SwitchbackSplitter,
     MLMExperimentAnalysis,
+    RelativePositivePerturbator,
+    StochasticPerturbator,
+    StochasticRelativePositivePerturbator,
 ]
 
 


### PR DESCRIPTION
In this PR, I am adding:
- `RelativePositivePerturbator`: a refactored version of a multiplicative perturbator originally developed by @DaniGate in a dev branch
- `StochasticPerturbator`: additive stochastic perturbator, it perturbs by sampling from a Normal distribution
- `StochasticRelativePositivePerturbator`: a fancy perturbator, multiplicative and stochastic, sampling from a Beta distribution between (ranged between 0 and 1). The beta is conveniently reparametrized with the mean and scale.


100% of diff lines are tested having an effect of increasing coverage above 98%.

![image](https://github.com/david26694/cluster-experiments/assets/7209800/a98eff68-df7d-47a7-9464-24126fa79abf)
