### PR TITLE
feat: allow washover-time int

### DIFF
--- a/cluster_experiments/power_config.py
+++ b/cluster_experiments/power_config.py
@@ -169,7 +169,7 @@ class PowerConfig:
                     "Overriding treatments to None."
                 )
 
-        if "stratified" not in self.splitter:
+        if "stratified" not in self.splitter and "ttest" not in self.analysis:
             if self._are_different(self.strata_cols, None):
                 self.strata_cols = None
                 logging.warning(
@@ -177,25 +177,25 @@ class PowerConfig:
                     "Overriding strata_cols to None."
                 )
 
-        if "cupac" not in self.analysis:
-            if self._are_different(self.agg_col, ""):
-                self.agg_col = ""
-                logging.warning(
-                    f"{self.agg_col = } has no effect with {self.analysis = }."
-                    "Overriding agg_col to None."
-                )
-            if self._are_different(self.smoothing_factor, 20):
-                self.smoothing_factor = 20
-                logging.warning(
-                    f"{self.smoothing_factor = } has no effect with {self.analysis = }."
-                    "Overriding smoothing_factor to 20."
-                )
-            if self._are_different(self.features_cupac_model, None):
-                self.features_cupac_model = None
-                logging.warning(
-                    f"{self.features_cupac_model = } has no effect with "
-                    f"{self.analysis = }. Overriding features_cupac_model to None."
-                )
+        # if "cupac" not in self.analysis:
+        #     if self._are_different(self.agg_col, ""):
+        #         self.agg_col = ""
+        #         logging.warning(
+        #             f"{self.agg_col = } has no effect with {self.analysis = }."
+        #             "Overriding agg_col to None."
+        #         )
+        #     if self._are_different(self.smoothing_factor, 20):
+        #         self.smoothing_factor = 20
+        #         logging.warning(
+        #             f"{self.smoothing_factor = } has no effect with {self.analysis = }."
+        #             "Overriding smoothing_factor to 20."
+        #         )
+        #     if self._are_different(self.features_cupac_model, None):
+        #         self.features_cupac_model = None
+        #         logging.warning(
+        #             f"{self.features_cupac_model = } has no effect with "
+        #             f"{self.analysis = }. Overriding features_cupac_model to None."
+        #         )
 
         if "ttest" in self.analysis:
             if self._are_different(self.covariates, None):

--- a/cluster_experiments/power_config.py
+++ b/cluster_experiments/power_config.py
@@ -31,7 +31,7 @@ from cluster_experiments.random_splitter import (
 )
 
 
-@dataclass
+@dataclass(frozen=True)
 class PowerConfig:
     """
     Dataclass to create a power analysis from.

--- a/cluster_experiments/power_config.py
+++ b/cluster_experiments/power_config.py
@@ -31,7 +31,7 @@ from cluster_experiments.random_splitter import (
 )
 
 
-@dataclass(frozen=True)
+@dataclass(eq=True)
 class PowerConfig:
     """
     Dataclass to create a power analysis from.

--- a/cluster_experiments/power_config.py
+++ b/cluster_experiments/power_config.py
@@ -145,13 +145,13 @@ class PowerConfig:
             if self._are_different(self.strata_cols, None):
                 self._set_and_log("strata_cols", None, "splitter")
 
-            if "cupac" == "":
-                if self._are_different(self.agg_col, ""):
-                    self._set_and_log("agg_col", "", "cupac")
-                if self._are_different(self.smoothing_factor, 20):
-                    self._set_and_log("smoothing_factor", 20, "cupac")
-                if self._are_different(self.features_cupac_model, None):
-                    self._set_and_log("features_cupac_model", None, "cupac")
+        if "cupac" == "":
+            if self._are_different(self.agg_col, ""):
+                self._set_and_log("agg_col", "", "cupac")
+            if self._are_different(self.smoothing_factor, 20):
+                self._set_and_log("smoothing_factor", 20, "cupac")
+            if self._are_different(self.features_cupac_model, None):
+                self._set_and_log("features_cupac_model", None, "cupac")
 
         if "ttest" in self.analysis:
             if self._are_different(self.covariates, None):

--- a/cluster_experiments/power_config.py
+++ b/cluster_experiments/power_config.py
@@ -41,6 +41,7 @@ class PowerConfig:
         splitter: Splitter object to use
         perturbator: Perturbator object to use
         analysis: ExperimentAnalysis object to use
+        washover: Washover object to use, defaults to ""
         cupac_model: CUPAC model to use
         n_simulations: number of simulations to run
         cluster_cols: list of columns to use as clusters
@@ -145,13 +146,13 @@ class PowerConfig:
             if self._are_different(self.strata_cols, None):
                 self._set_and_log("strata_cols", None, "splitter")
 
-        if "cupac" == "":
+        if self.cupac_model == "":
             if self._are_different(self.agg_col, ""):
-                self._set_and_log("agg_col", "", "cupac")
+                self._set_and_log("agg_col", "", "cupac_model")
             if self._are_different(self.smoothing_factor, 20):
-                self._set_and_log("smoothing_factor", 20, "cupac")
+                self._set_and_log("smoothing_factor", 20, "cupac_model")
             if self._are_different(self.features_cupac_model, None):
-                self._set_and_log("features_cupac_model", None, "cupac")
+                self._set_and_log("features_cupac_model", None, "cupac_model")
 
         if "ttest" in self.analysis:
             if self._are_different(self.covariates, None):

--- a/cluster_experiments/power_config.py
+++ b/cluster_experiments/power_config.py
@@ -173,27 +173,27 @@ class PowerConfig:
                 if self._are_different(self.agg_col, ""):
                     self.agg_col = ""
                     logging.warning(
-                        f"{self.agg_col = } has no effect with {self.analysis = }."
+                        f"{self.agg_col = } has no effect with {self.cupac = }."
                         "Overriding agg_col to None."
                     )
                 if self._are_different(self.smoothing_factor, 20):
                     self.smoothing_factor = 20
                     logging.warning(
-                        f"{self.smoothing_factor = } has no effect with {self.analysis = }."
+                        f"{self.smoothing_factor = } has no effect with {self.cupac = }."
                         "Overriding smoothing_factor to 20."
                     )
                 if self._are_different(self.features_cupac_model, None):
                     self.features_cupac_model = None
                     logging.warning(
                         f"{self.features_cupac_model = } has no effect with "
-                        f"{self.analysis = }. Overriding features_cupac_model to None."
+                        f"{self.cupac = }. Overriding features_cupac_model to None."
                     )
 
         if "ttest" in self.analysis:
             if self._are_different(self.covariates, None):
                 self.covariates = None
                 logging.warning(
-                    f"{self.covariates = } has no effect with {self.analysis = }."
+                    f"{self.covariates = } has no effect with {self.cupac = }."
                     "Overriding covariates to None."
                 )
 

--- a/cluster_experiments/power_config.py
+++ b/cluster_experiments/power_config.py
@@ -125,30 +125,29 @@ class PowerConfig:
 
     seed: Optional[int] = None
 
+    def __post_init__(self):
+        if "switchback" not in self.splitter:
+            self.switch_frequency = None
+            self.washover_time_delta = None
+            self.washover = ""
+            self.time_col = None
 
-def __post_init__(self):
-    if "switchback" not in self.splitter:
-        self.switch_frequency = None
-        self.washover_time_delta = None
-        self.washover = ""
-        self.time_col = None
+        if self.perturbator not in {"normal", "beta_relative_positive"}:
+            self.scale = None
 
-    if self.perturbator not in {"normal", "beta_relative_positive"}:
-        self.scale = None
+        if "balanced" not in self.splitter:
+            self.treatments = None
 
-    if "balanced" not in self.splitter:
-        self.treatments = None
+        if "stratified" not in self.splitter:
+            self.strata_cols = None
 
-    if "stratified" not in self.splitter:
-        self.strata_cols = None
+        if "cupac" not in self.analysis:
+            self.agg_col = ""
+            self.smoothing_factor = 20
+            self.features_cupac_model = None
 
-    if "cupac" not in self.analysis:
-        self.agg_col = ""
-        self.smoothing_factor = 20
-        self.features_cupac_model = None
-
-    if "ttest" in self.analysis:
-        self.covariates = None
+        if "ttest" in self.analysis:
+            self.covariates = None
 
 
 perturbator_mapping = {

--- a/cluster_experiments/power_config.py
+++ b/cluster_experiments/power_config.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime
+import logging
 from dataclasses import dataclass
 from typing import List, Optional
 
@@ -124,6 +125,37 @@ class PowerConfig:
     features_cupac_model: Optional[List[str]] = None
 
     seed: Optional[int] = None
+
+
+def __post_init__(self):
+    if "switchback" not in self.splitter:
+        logging.warning("Not a switchback, setting switchback parameters to defaults")
+        self.switch_frequency = None
+        self.washover_time_delta = None
+        self.washover = ""
+        self.time_col = None
+
+    if self.perturbator not in {"normal", "beta_relative_positive"}:
+        logging.warning("Non stochastic Perturbator, setting scale to None")
+        self.scale = None
+
+    if "balanced" not in self.splitter:
+        logging.warning("Non balanced splitter, setting treatments to None")
+        self.treatments = None
+
+    if "stratified" not in self.splitter:
+        logging.warning("Non stratified splitter, setting strata_cols to None")
+        self.strata_cols = None
+
+    if "cupac" not in self.analysis:
+        logging.warning("No Cupac analyser, setting Cupac params to defaults")
+        self.agg_col = ""
+        self.smoothing_factor = 20
+        self.features_cupac_model = None
+
+    if "ttest" in self.analysis:
+        logging.warning("T-test analyser, setting covariates to None")
+        self.covariates = None
 
 
 perturbator_mapping = {

--- a/cluster_experiments/power_config.py
+++ b/cluster_experiments/power_config.py
@@ -161,15 +161,7 @@ class PowerConfig:
                     "Overriding scale to None."
                 )
 
-        if "balanced" not in self.splitter:
-            if self._are_different(self.treatments, None):
-                self.treatments = None
-                logging.warning(
-                    f"{self.treatments = } has no effect with {self.splitter = }."
-                    "Overriding treatments to None."
-                )
-
-        if "stratified" not in self.splitter and "ttest" not in self.analysis:
+        if "stratified" not in self.splitter and "paired_ttest" not in self.analysis:
             if self._are_different(self.strata_cols, None):
                 self.strata_cols = None
                 logging.warning(
@@ -177,25 +169,25 @@ class PowerConfig:
                     "Overriding strata_cols to None."
                 )
 
-        # if "cupac" not in self.analysis:
-        #     if self._are_different(self.agg_col, ""):
-        #         self.agg_col = ""
-        #         logging.warning(
-        #             f"{self.agg_col = } has no effect with {self.analysis = }."
-        #             "Overriding agg_col to None."
-        #         )
-        #     if self._are_different(self.smoothing_factor, 20):
-        #         self.smoothing_factor = 20
-        #         logging.warning(
-        #             f"{self.smoothing_factor = } has no effect with {self.analysis = }."
-        #             "Overriding smoothing_factor to 20."
-        #         )
-        #     if self._are_different(self.features_cupac_model, None):
-        #         self.features_cupac_model = None
-        #         logging.warning(
-        #             f"{self.features_cupac_model = } has no effect with "
-        #             f"{self.analysis = }. Overriding features_cupac_model to None."
-        #         )
+            if "cupac" == "":
+                if self._are_different(self.agg_col, ""):
+                    self.agg_col = ""
+                    logging.warning(
+                        f"{self.agg_col = } has no effect with {self.analysis = }."
+                        "Overriding agg_col to None."
+                    )
+                if self._are_different(self.smoothing_factor, 20):
+                    self.smoothing_factor = 20
+                    logging.warning(
+                        f"{self.smoothing_factor = } has no effect with {self.analysis = }."
+                        "Overriding smoothing_factor to 20."
+                    )
+                if self._are_different(self.features_cupac_model, None):
+                    self.features_cupac_model = None
+                    logging.warning(
+                        f"{self.features_cupac_model = } has no effect with "
+                        f"{self.analysis = }. Overriding features_cupac_model to None."
+                    )
 
         if "ttest" in self.analysis:
             if self._are_different(self.covariates, None):

--- a/cluster_experiments/power_config.py
+++ b/cluster_experiments/power_config.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 from dataclasses import dataclass
 from typing import List, Optional

--- a/cluster_experiments/power_config.py
+++ b/cluster_experiments/power_config.py
@@ -129,7 +129,7 @@ class PowerConfig:
     def __post_init__(self):
         if "switchback" not in self.splitter:
             if self._are_different(self.switch_frequency, None):
-                self._set_and_log("swithc_frequency", None, "splitter")
+                self._set_and_log("switch_frequency", None, "splitter")
             if self._are_different(self.washover_time_delta, None):
                 self._set_and_log("washover_time_delta", None, "splitter")
             if self._are_different(self.washover, ""):

--- a/cluster_experiments/power_config.py
+++ b/cluster_experiments/power_config.py
@@ -129,76 +129,44 @@ class PowerConfig:
     def __post_init__(self):
         if "switchback" not in self.splitter:
             if self._are_different(self.switch_frequency, None):
-                self.switch_frequency = None
-                logging.warning(
-                    f"{self.switch_frequency = } has no effect"
-                    f"with {self.splitter = }. Overriding switch_frequency to None."
-                )
+                self._set_and_log("swithc_frequency", None, "splitter")
             if self._are_different(self.washover_time_delta, None):
-                self.washover_time_delta = None
-                logging.warning(
-                    f"{self.washover_time_delta = } has no effect"
-                    f"with {self.splitter = }. Overriding washover_time_delta to None."
-                )
+                self._set_and_log("washover_time_delta", None, "splitter")
             if self._are_different(self.washover, ""):
-                self.washover = ""
-                logging.warning(
-                    f"{self.washover = } has no effect with {self.splitter = }."
-                    'Overriding washover to "".'
-                )
+                self._set_and_log("washover", "", "splitter")
             if self._are_different(self.time_col, None):
-                self.time_col = None
-                logging.warning(
-                    f"{self.time_col = } has no effect with {self.splitter = } "
-                    "Splitter. Overriding time_col to None."
-                )
+                self._set_and_log("time_col", None, "splitter")
 
         if self.perturbator not in {"normal", "beta_relative_positive"}:
             if self._are_different(self.scale, None):
-                self.scale = None
-                logging.warning(
-                    f"{self.scale = } has no effect with {self.perturbator = }."
-                    "Overriding scale to None."
-                )
+                self._set_and_log("scale", None, "perturbator")
 
         if "stratified" not in self.splitter and "paired_ttest" not in self.analysis:
             if self._are_different(self.strata_cols, None):
-                self.strata_cols = None
-                logging.warning(
-                    f"{self.strata_cols = } has no effect with {self.splitter = }."
-                    "Overriding strata_cols to None."
-                )
+                self._set_and_log("strata_cols", None, "splitter")
 
             if "cupac" == "":
                 if self._are_different(self.agg_col, ""):
-                    self.agg_col = ""
-                    logging.warning(
-                        f"{self.agg_col = } has no effect with {self.cupac = }."
-                        "Overriding agg_col to None."
-                    )
+                    self._set_and_log("agg_col", "", "cupac")
                 if self._are_different(self.smoothing_factor, 20):
-                    self.smoothing_factor = 20
-                    logging.warning(
-                        f"{self.smoothing_factor = } has no effect with {self.cupac = }."
-                        "Overriding smoothing_factor to 20."
-                    )
+                    self._set_and_log("smoothing_factor", 20, "cupac")
                 if self._are_different(self.features_cupac_model, None):
-                    self.features_cupac_model = None
-                    logging.warning(
-                        f"{self.features_cupac_model = } has no effect with "
-                        f"{self.cupac = }. Overriding features_cupac_model to None."
-                    )
+                    self._set_and_log("features_cupac_model", None, "cupac")
 
         if "ttest" in self.analysis:
             if self._are_different(self.covariates, None):
-                self.covariates = None
-                logging.warning(
-                    f"{self.covariates = } has no effect with {self.cupac = }."
-                    "Overriding covariates to None."
-                )
+                self._set_and_log("covariates", None, "analysis")
 
     def _are_different(self, arg1, arg2) -> bool:
         return arg1 != arg2
+
+    def _set_and_log(self, attr, value, other_attr):
+        logging.warning(
+            f"{attr} = {getattr(self, attr)} has no effect with "
+            f"{other_attr} = {getattr(self, other_attr)}. "
+            f"Overriding {attr} to {value}."
+        )
+        setattr(self, attr, value)
 
 
 perturbator_mapping = {

--- a/cluster_experiments/power_config.py
+++ b/cluster_experiments/power_config.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import datetime
-import logging
 from dataclasses import dataclass
 from typing import List, Optional
 
@@ -129,32 +128,26 @@ class PowerConfig:
 
 def __post_init__(self):
     if "switchback" not in self.splitter:
-        logging.warning("Not a switchback, setting switchback parameters to defaults")
         self.switch_frequency = None
         self.washover_time_delta = None
         self.washover = ""
         self.time_col = None
 
     if self.perturbator not in {"normal", "beta_relative_positive"}:
-        logging.warning("Non stochastic Perturbator, setting scale to None")
         self.scale = None
 
     if "balanced" not in self.splitter:
-        logging.warning("Non balanced splitter, setting treatments to None")
         self.treatments = None
 
     if "stratified" not in self.splitter:
-        logging.warning("Non stratified splitter, setting strata_cols to None")
         self.strata_cols = None
 
     if "cupac" not in self.analysis:
-        logging.warning("No Cupac analyser, setting Cupac params to defaults")
         self.agg_col = ""
         self.smoothing_factor = 20
         self.features_cupac_model = None
 
     if "ttest" in self.analysis:
-        logging.warning("T-test analyser, setting covariates to None")
         self.covariates = None
 
 

--- a/cluster_experiments/power_config.py
+++ b/cluster_experiments/power_config.py
@@ -49,6 +49,7 @@ class PowerConfig:
         splitter_weights: weights to use for the splitter, should have the same length as treatments, each weight should correspond to an element in treatments
         switch_frequency: how often to switch treatments
         time_col: column to use as time in switchback splitter
+        washover_time_delta: optional, int indicating the washover time in minutes or datetime.timedelta object
         covariates: list of columns to use as covariates
         average_effect: average effect to use in the perturbator
         scale: scale to use in stochastic perturbators
@@ -105,7 +106,7 @@ class PowerConfig:
     switch_frequency: Optional[str] = None
     # Switchback
     time_col: Optional[str] = None
-    washover_time_delta: Optional[datetime.timedelta] = None
+    washover_time_delta: Optional[datetime.timedelta | int] = None
 
     # Analysis
     covariates: Optional[List[str]] = None

--- a/cluster_experiments/power_config.py
+++ b/cluster_experiments/power_config.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime
+import logging
 from dataclasses import dataclass
 from typing import List, Optional
 
@@ -127,27 +128,85 @@ class PowerConfig:
 
     def __post_init__(self):
         if "switchback" not in self.splitter:
-            self.switch_frequency = None
-            self.washover_time_delta = None
-            self.washover = ""
-            self.time_col = None
+            if self._are_different(self.switch_frequency, None):
+                self.switch_frequency = None
+                logging.warning(
+                    f"{self.switch_frequency = } has no effect"
+                    f"with {self.splitter = }. Overriding switch_frequency to None."
+                )
+            if self._are_different(self.washover_time_delta, None):
+                self.washover_time_delta = None
+                logging.warning(
+                    f"{self.washover_time_delta = } has no effect"
+                    f"with {self.splitter = }. Overriding washover_time_delta to None."
+                )
+            if self._are_different(self.washover, ""):
+                self.washover = ""
+                logging.warning(
+                    f"{self.washover = } has no effect with {self.splitter = }."
+                    'Overriding washover to "".'
+                )
+            if self._are_different(self.time_col, None):
+                self.time_col = None
+                logging.warning(
+                    f"{self.time_col = } has no effect with {self.splitter = } "
+                    "Splitter. Overriding time_col to None."
+                )
 
         if self.perturbator not in {"normal", "beta_relative_positive"}:
-            self.scale = None
+            if self._are_different(self.scale, None):
+                self.scale = None
+                logging.warning(
+                    f"{self.scale = } has no effect with {self.perturbator = }."
+                    "Overriding scale to None."
+                )
 
         if "balanced" not in self.splitter:
-            self.treatments = None
+            if self._are_different(self.treatments, None):
+                self.treatments = None
+                logging.warning(
+                    f"{self.treatments = } has no effect with {self.splitter = }."
+                    "Overriding treatments to None."
+                )
 
         if "stratified" not in self.splitter:
-            self.strata_cols = None
+            if self._are_different(self.strata_cols, None):
+                self.strata_cols = None
+                logging.warning(
+                    f"{self.strata_cols = } has no effect with {self.splitter = }."
+                    "Overriding strata_cols to None."
+                )
 
         if "cupac" not in self.analysis:
-            self.agg_col = ""
-            self.smoothing_factor = 20
-            self.features_cupac_model = None
+            if self._are_different(self.agg_col, ""):
+                self.agg_col = ""
+                logging.warning(
+                    f"{self.agg_col = } has no effect with {self.analysis = }."
+                    "Overriding agg_col to None."
+                )
+            if self._are_different(self.smoothing_factor, 20):
+                self.smoothing_factor = 20
+                logging.warning(
+                    f"{self.smoothing_factor = } has no effect with {self.analysis = }."
+                    "Overriding smoothing_factor to 20."
+                )
+            if self._are_different(self.features_cupac_model, None):
+                self.features_cupac_model = None
+                logging.warning(
+                    f"{self.features_cupac_model = } has no effect with "
+                    f"{self.analysis = }. Overriding features_cupac_model to None."
+                )
 
         if "ttest" in self.analysis:
-            self.covariates = None
+            if self._are_different(self.covariates, None):
+                self.covariates = None
+                logging.warning(
+                    f"{self.covariates = } has no effect with {self.analysis = }."
+                    "Overriding covariates to None."
+                )
+
+    def _are_different(self, arg1, arg2) -> bool:
+        return arg1 != arg2
 
 
 perturbator_mapping = {

--- a/cluster_experiments/washover.py
+++ b/cluster_experiments/washover.py
@@ -175,9 +175,11 @@ class ConstantWashover(Washover):
             raise ValueError(
                 f"Washover time delta must be specified for ConstantWashover, while it is {config.washover_time_delta = }"
             )
-        return cls(
-            washover_time_delta=config.washover_time_delta,
-        )
+
+        washover_time_delta = config.washover_time_delta
+        if isinstance(washover_time_delta, int):
+            washover_time_delta = datetime.timedelta(minutes=config.washover_time_delta)
+        return cls(washover_time_delta=washover_time_delta)
 
 
 # This is kept in here because of circular imports, need to rethink this

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ dev_packages = test_packages + util_packages + docs_packages
 
 setup(
     name="cluster_experiments",
-    version="0.8.2",
+    version="0.8.3",
     packages=find_packages(),
     extras_require={
         "dev": dev_packages,

--- a/tests/power_config/test_warnings_superfluous_params.py
+++ b/tests/power_config/test_warnings_superfluous_params.py
@@ -1,0 +1,153 @@
+import logging
+
+from cluster_experiments.power_config import PowerConfig
+
+
+def test_config_warning_superfluous_param_switch_frequency(caplog):
+    msg = "switch_frequency = 1H has no effect with splitter = non_clustered. Overriding switch_frequency to None."
+    with caplog.at_level(logging.WARNING):
+        PowerConfig(
+            cluster_cols=["cluster", "date"],
+            analysis="ols_non_clustered",
+            perturbator="uniform",
+            splitter="non_clustered",
+            n_simulations=4,
+            average_effect=1.5,
+            switch_frequency="1H",
+        )
+    assert msg in caplog.text
+
+
+def test_config_warning_superfluous_param_washover_time_delta(caplog):
+    msg = "washover_time_delta = 30 has no effect with splitter = non_clustered. Overriding washover_time_delta to None."
+    with caplog.at_level(logging.WARNING):
+        PowerConfig(
+            cluster_cols=["cluster", "date"],
+            analysis="ols_non_clustered",
+            perturbator="uniform",
+            splitter="non_clustered",
+            n_simulations=4,
+            average_effect=1.5,
+            washover_time_delta=30,
+        )
+    assert msg in caplog.text
+
+
+def test_config_warning_superfluous_param_washover(caplog):
+    msg = "washover = constant_washover has no effect with splitter = non_clustered. Overriding washover to ."
+    with caplog.at_level(logging.WARNING):
+        PowerConfig(
+            cluster_cols=["cluster", "date"],
+            analysis="ols_non_clustered",
+            perturbator="uniform",
+            splitter="non_clustered",
+            n_simulations=4,
+            average_effect=1.5,
+            washover="constant_washover",
+        )
+    assert msg in caplog.text
+
+
+def test_config_warning_superfluous_param_time_col(caplog):
+    msg = "time_col = datetime has no effect with splitter = non_clustered. Overriding time_col to None."
+    with caplog.at_level(logging.WARNING):
+        PowerConfig(
+            cluster_cols=["cluster", "date"],
+            analysis="ols_non_clustered",
+            perturbator="uniform",
+            splitter="non_clustered",
+            n_simulations=4,
+            average_effect=1.5,
+            time_col="datetime",
+        )
+    assert msg in caplog.text
+
+
+def test_config_warning_superfluous_param_perturbator(caplog):
+    msg = "scale = 0.5 has no effect with perturbator = uniform. Overriding scale to None."
+    with caplog.at_level(logging.WARNING):
+        PowerConfig(
+            cluster_cols=["cluster", "date"],
+            analysis="ols_non_clustered",
+            perturbator="uniform",
+            splitter="non_clustered",
+            n_simulations=4,
+            average_effect=1.5,
+            scale=0.5,
+        )
+    assert msg in caplog.text
+
+
+def test_config_warning_superfluous_param_strata_cols(caplog):
+    msg = "strata_cols = ['group'] has no effect with splitter = non_clustered. Overriding strata_cols to None."
+    with caplog.at_level(logging.WARNING):
+        PowerConfig(
+            cluster_cols=["cluster", "date"],
+            analysis="ols_non_clustered",
+            perturbator="uniform",
+            splitter="non_clustered",
+            n_simulations=4,
+            average_effect=1.5,
+            strata_cols=["group"],
+        )
+    assert msg in caplog.text
+
+
+def test_config_warning_superfluous_param_agg_col(caplog):
+    msg = "agg_col = agg_col has no effect with cupac_model = . Overriding agg_col to ."
+    with caplog.at_level(logging.WARNING):
+        PowerConfig(
+            cluster_cols=["cluster", "date"],
+            analysis="ols_non_clustered",
+            perturbator="uniform",
+            splitter="non_clustered",
+            n_simulations=4,
+            average_effect=1.5,
+            agg_col="agg_col",
+        )
+    assert msg in caplog.text
+
+
+def test_config_warning_superfluous_param_smoothing_factor(caplog):
+    msg = "smoothing_factor = 0.5 has no effect with cupac_model = . Overriding smoothing_factor to 20."
+    with caplog.at_level(logging.WARNING):
+        PowerConfig(
+            cluster_cols=["cluster", "date"],
+            analysis="ols_non_clustered",
+            perturbator="uniform",
+            splitter="non_clustered",
+            n_simulations=4,
+            average_effect=1.5,
+            smoothing_factor=0.5,
+        )
+    assert msg in caplog.text
+
+
+def test_config_warning_superfluous_param_features_cupac_model(caplog):
+    msg = "features_cupac_model = ['feature1'] has no effect with cupac_model = . Overriding features_cupac_model to None."
+    with caplog.at_level(logging.WARNING):
+        PowerConfig(
+            cluster_cols=["cluster", "date"],
+            analysis="ols_clustered",
+            perturbator="uniform",
+            splitter="non_clustered",
+            n_simulations=4,
+            average_effect=1.5,
+            features_cupac_model=["feature1"],
+        )
+    assert msg in caplog.text
+
+
+def test_config_warning_superfluous_param_covariates(caplog):
+    msg = "covariates = ['covariate1'] has no effect with analysis = ttest_clustered. Overriding covariates to None."
+    with caplog.at_level(logging.WARNING):
+        PowerConfig(
+            cluster_cols=["cluster", "date"],
+            analysis="ttest_clustered",
+            perturbator="uniform",
+            splitter="non_clustered",
+            n_simulations=4,
+            average_effect=1.5,
+            covariates=["covariate1"],
+        )
+    assert msg in caplog.text


### PR DESCRIPTION
In this PR, I am adding warnings when superfluous params are provided to the `PowerConfig`. Superfluous params are those that have no effect in the power simulations run. It also overrides these superfluous params to the default values. In this way, if config1 and config2 differ in superfluous params, this code `config1 == config2` will eval to True.