### PR TITLE
Add MissingArgumentException

### DIFF
--- a/cluster_experiments/power_analysis.py
+++ b/cluster_experiments/power_analysis.py
@@ -284,8 +284,7 @@ class PowerAnalysis:
         n_detected_mde = 0
         for _ in tqdm(range(n_simulations), disable=not verbose):
             p_value = self._run_simulation((df, average_effect))
-            if verbose:
-                logging.info(f"p_value of simulation run: {p_value:.3f}")
+            logging.info(f"p_value of simulation run: {p_value:.3f}")
             n_detected_mde += p_value < alpha
 
         return n_detected_mde / n_simulations

--- a/cluster_experiments/power_analysis.py
+++ b/cluster_experiments/power_analysis.py
@@ -285,7 +285,7 @@ class PowerAnalysis:
         for _ in tqdm(range(n_simulations), disable=not verbose):
             p_value = self._run_simulation((df, average_effect))
             if verbose:
-                print(f"p_value of simulation run: {p_value:.3f}")
+                logging.info(f"p_value of simulation run: {p_value:.3f}")
             n_detected_mde += p_value < alpha
 
         return n_detected_mde / n_simulations

--- a/cluster_experiments/power_analysis.py
+++ b/cluster_experiments/power_analysis.py
@@ -284,7 +284,8 @@ class PowerAnalysis:
         n_detected_mde = 0
         for _ in tqdm(range(n_simulations), disable=not verbose):
             p_value = self._run_simulation((df, average_effect))
-            logging.info(f"p_value of simulation run: {p_value:.3f}")
+            if verbose:
+                print(f"p_value of simulation run: {p_value:.3f}")
             n_detected_mde += p_value < alpha
 
         return n_detected_mde / n_simulations

--- a/cluster_experiments/power_config.py
+++ b/cluster_experiments/power_config.py
@@ -34,6 +34,10 @@ from cluster_experiments.random_splitter import (
 )
 
 
+class MissingArgumentError(ValueError):
+    pass
+
+
 @dataclass(eq=True)
 class PowerConfig:
     """
@@ -185,6 +189,9 @@ class PowerConfig:
             if self._are_different(self.covariates, None):
                 self._set_and_log("covariates", None, "analysis")
 
+        if "segmented" in self.perturbator:
+            self._raise_error_if_missing("segment_cols", "perturbator")
+
     def _are_different(self, arg1, arg2) -> bool:
         return arg1 != arg2
 
@@ -195,6 +202,13 @@ class PowerConfig:
             f"Overriding {attr} to {value}."
         )
         setattr(self, attr, value)
+
+    def _raise_error_if_missing(self, attr, other_attr):
+        if getattr(self, attr) is None:
+            raise MissingArgumentError(
+                f"{attr} is required when using "
+                f"{other_attr} = {getattr(self, other_attr)}."
+            )
 
 
 perturbator_mapping = {

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ dev_packages = test_packages + util_packages + docs_packages
 
 setup(
     name="cluster_experiments",
-    version="0.10.0",
+    version="0.10.1",
     packages=find_packages(),
     extras_require={
         "dev": dev_packages,

--- a/tests/power_config/test_missing_arguments_error.py
+++ b/tests/power_config/test_missing_arguments_error.py
@@ -1,0 +1,16 @@
+import pytest
+
+from cluster_experiments.power_config import MissingArgumentError, PowerConfig
+
+
+def test_missing_argument_segment_cols(caplog):
+    msg = "segment_cols is required when using perturbator = segmented_beta_relative."
+    with pytest.raises(MissingArgumentError, match=msg):
+        PowerConfig(
+            cluster_cols=["cluster"],
+            analysis="mlm",
+            perturbator="segmented_beta_relative",
+            splitter="non_clustered",
+            n_simulations=4,
+            average_effect=1.5,
+        )


### PR DESCRIPTION
Maybe should be added for other parameters as well, to catch faulty configs at "init-time" rather than when trying to run the analysis (e.g. I just saw the PR, for which we could raise the error also in the config already: https://github.com/david26694/cluster-experiments/pull/130)