### PR TITLE
feat: add running power estimates

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ dev_packages = test_packages + util_packages + docs_packages
 
 setup(
     name="cluster_experiments",
-    version="0.10.3",
+    version="0.10.4",
     packages=find_packages(),
     extras_require={
         "dev": dev_packages,

--- a/tests/power_analysis/test_power_analysis.py
+++ b/tests/power_analysis/test_power_analysis.py
@@ -223,3 +223,18 @@ def test_power_line(df):
     assert len(power_line) == 2
     assert power_line[0.0] >= 0
     assert power_line[1.0] >= power_line[0.0]
+
+
+def test_running_power(df):
+    config = PowerConfig(
+        analysis="ols_non_clustered",
+        perturbator="constant",
+        splitter="non_clustered",
+        n_simulations=10,
+        average_effect=0.0,
+        alpha=0.05,
+    )
+    pw = PowerAnalysis.from_config(config)
+    for power in pw.running_power_analysis(df, average_effect=0.1):
+        assert power >= 0
+        assert power <= 1

--- a/tests/power_analysis/test_power_analysis.py
+++ b/tests/power_analysis/test_power_analysis.py
@@ -226,15 +226,20 @@ def test_power_line(df):
 
 
 def test_running_power(df):
+    # given
     config = PowerConfig(
         analysis="ols_non_clustered",
         perturbator="constant",
         splitter="non_clustered",
-        n_simulations=10,
+        n_simulations=50,
         average_effect=0.0,
         alpha=0.05,
     )
     pw = PowerAnalysis.from_config(config)
-    for power in pw.running_power_analysis(df, average_effect=0.1):
-        assert power >= 0
-        assert power <= 1
+    previous_power = 0
+    for i, power in enumerate(pw.running_power_analysis(df, average_effect=0.1)):
+        # when: we've run enough simulations
+        if i > 20:
+            # then: the power should be stable (no changes bigger than 0.05)
+            assert abs(power - previous_power) <= 0.05
+        previous_power = power


### PR DESCRIPTION
Used for slow power calculations, it is good to have some feedback before waiting for the whole simulation to run