### PR TITLE
fix: sort values before the shift function

### DIFF
--- a/cluster_experiments/washover.py
+++ b/cluster_experiments/washover.py
@@ -148,7 +148,8 @@ class ConstantWashover(Washover):
         # Cluster columns that do not involve time
         non_time_cols = list(set(cluster_cols) - set([truncated_time_col]))
         # For each cluster, we need to check if treatment has changed wrt last time
-        df_agg = df.drop_duplicates(subset=cluster_cols + [treatment_col]).copy()
+        df_agg = df.sort_values([original_time_col]).copy()
+        df_agg = df_agg.drop_duplicates(subset=cluster_cols + [treatment_col])
         df_agg["__changed"] = (
             df_agg.groupby(non_time_cols)[treatment_col].shift(1)
             != df_agg[treatment_col]

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ dev_packages = test_packages + util_packages + docs_packages
 
 setup(
     name="cluster_experiments",
-    version="0.11.0",
+    version="0.12.0",
     packages=find_packages(),
     extras_require={
         "dev": dev_packages,


### PR DESCRIPTION
Adding a sort before the shift, so we get the correct "last switch" from the dataset