### PR TITLE
fix: washover for cases with 0 non_time_cols

### DIFF
--- a/cluster_experiments/washover.py
+++ b/cluster_experiments/washover.py
@@ -203,10 +203,16 @@ class ConstantWashover(Washover):
         # For each cluster, we need to check if treatment has changed wrt last time
         df_agg = df.sort_values([original_time_col]).copy()
         df_agg = df_agg.drop_duplicates(subset=cluster_cols + [treatment_col])
-        df_agg["__changed"] = (
-            df_agg.groupby(non_time_cols)[treatment_col].shift(1)
-            != df_agg[treatment_col]
-        )
+
+        if non_time_cols:
+            df_agg["__changed"] = (
+                df_agg.groupby(non_time_cols)[treatment_col].shift(1)
+                != df_agg[treatment_col]
+            )
+        else:
+            df_agg["__changed"] = (
+                df_agg[treatment_col].shift(1) != df_agg[treatment_col]
+            )
         df_agg = df_agg.loc[:, cluster_cols + ["__changed"]]
         return (
             df.merge(df_agg, on=cluster_cols, how="inner")

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ dev_packages = test_packages + util_packages + docs_packages
 
 setup(
     name="cluster_experiments",
-    version="0.13.0",
+    version="0.14.0",
     packages=find_packages(),
     extras_require={
         "dev": dev_packages,

--- a/tests/splitter/conftest.py
+++ b/tests/splitter/conftest.py
@@ -213,3 +213,16 @@ def washover_split_df(n):
             "city": random.choices(["TGN", "NYC", "LON", "REU"], k=n),
         }
     )
+
+
+@pytest.fixture
+def washover_split_no_city_df(n):
+    # Return
+    return pd.DataFrame(
+        {
+            # Random time each minute in 2022-01-01, length 1000
+            "time": pd.date_range("2022-01-01", "2022-01-02", freq="1min")[
+                np.random.randint(24 * 60, size=n)
+            ],
+        }
+    )

--- a/tests/splitter/test_washover.py
+++ b/tests/splitter/test_washover.py
@@ -53,7 +53,7 @@ def test_constant_washover_no_switch(minutes, n_rows, df, request):
 
 
 @pytest.mark.parametrize(
-    "minutes, n",
+    "minutes, n,",
     [
         (15, 10000),
     ],
@@ -70,6 +70,35 @@ def test_constant_washover_split(minutes, n, washover_split_df):
     )
 
     out_df = splitter.assign_treatment_df(df=washover_split_df)
+
+    # Assert A and B in out_df
+    assert set(out_df["treatment"].unique()) == {"A", "B"}
+
+    # We need to have less than 10000 rows
+    assert len(out_df) < n
+
+    # We need to have more than 5000 rows (this is because ABB doesn't do washover on the second split)
+    assert len(out_df) > n / 2
+
+
+@pytest.mark.parametrize(
+    "minutes, n,",
+    [
+        (15, 1000),
+    ],
+)
+def test_constant_washover_split_no_city(minutes, n, washover_split_no_city_df):
+    washover = ConstantWashover(washover_time_delta=timedelta(minutes=minutes))
+
+    splitter = SwitchbackSplitter(
+        washover=washover,
+        time_col="time",
+        cluster_cols=["time"],
+        treatment_col="treatment",
+        switch_frequency="30T",
+    )
+
+    out_df = splitter.assign_treatment_df(df=washover_split_no_city_df)
 
     # Assert A and B in out_df
     assert set(out_df["treatment"].unique()) == {"A", "B"}


### PR DESCRIPTION
Hey David! :wave:

Currently, if you try to add a washover for a switchback experiment where the only cluster is time, it fails with: `ValueError: No group keys passed!`
The test I proposed can reproduce the bug.

The solution is just to handle the case with non-grouping columns in the simplest way possible.

Let me know if you have any comments.