### PR TITLE
Update cluster_cols on random_splitter.py

### DIFF
--- a/cluster_experiments/random_splitter.py
+++ b/cluster_experiments/random_splitter.py
@@ -189,6 +189,8 @@ class SwitchbackSplitter(ClusteredSplitter):
         # Overwriting column, this is the worst! If we use the column as a covariate, we're screwed. Needs improvement
         df[_original_time_column(self.time_col)] = df[self.time_col]
         df[self.time_col] = self._get_time_col_cluster(df)
+        # add time_col if it is not already there
+        self.cluster_cols = list(set(self.cluster_cols + [self.time_col]))
         return df
 
     def assign_treatment_df(

--- a/cluster_experiments/random_splitter.py
+++ b/cluster_experiments/random_splitter.py
@@ -174,6 +174,9 @@ class SwitchbackSplitter(ClusteredSplitter):
         self.splitter_weights = splitter_weights
         self.washover = washover or EmptyWashover()
 
+        # add time_col if it is not already there
+        self.cluster_cols = list(set(self.cluster_cols + [self.time_col]))
+
     def _get_time_col_cluster(self, df: pd.DataFrame) -> pd.Series:
         df = df.copy()
         df[self.time_col] = pd.to_datetime(df[self.time_col])
@@ -189,8 +192,6 @@ class SwitchbackSplitter(ClusteredSplitter):
         # Overwriting column, this is the worst! If we use the column as a covariate, we're screwed. Needs improvement
         df[_original_time_column(self.time_col)] = df[self.time_col]
         df[self.time_col] = self._get_time_col_cluster(df)
-        # add time_col if it is not already there
-        self.cluster_cols = list(set(self.cluster_cols + [self.time_col]))
         return df
 
     def assign_treatment_df(

--- a/cluster_experiments/random_splitter.py
+++ b/cluster_experiments/random_splitter.py
@@ -175,7 +175,8 @@ class SwitchbackSplitter(ClusteredSplitter):
         self.washover = washover or EmptyWashover()
 
         # add time_col if it is not already there
-        self.cluster_cols = list(set(self.cluster_cols + [self.time_col]))
+        if self.time_col not in self.cluster_cols:
+            self.cluster_cols = list(set(self.cluster_cols + [self.time_col]))
 
     def _get_time_col_cluster(self, df: pd.DataFrame) -> pd.Series:
         df = df.copy()

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ dev_packages = test_packages + util_packages + docs_packages
 
 setup(
     name="cluster_experiments",
-    version="0.14.0",
+    version="0.14.1",
     packages=find_packages(),
     extras_require={
         "dev": dev_packages,

--- a/tests/power_analysis/test_multivariate.py
+++ b/tests/power_analysis/test_multivariate.py
@@ -60,6 +60,7 @@ def binary_hypothesis_power_config():
         "perturbator": "constant",
         "splitter": "non_clustered",
         "n_simulations": 50,
+        "seed": 220924,
     }
     return PowerAnalysis.from_dict(config)
 
@@ -72,6 +73,7 @@ def multivariate_hypothesis_power_config():
         "splitter": "non_clustered",
         "n_simulations": 50,
         "treatments": ["A", "B", "C", "D", "E", "F", "G"],
+        "seed": 220924,
     }
     return PowerAnalysis.from_dict(config)
 

--- a/tests/power_analysis/test_switchback_power.py
+++ b/tests/power_analysis/test_switchback_power.py
@@ -91,7 +91,7 @@ def test_switchback_strata():
         "perturbator": "constant",
         "analysis": "ols_clustered",
         "splitter": "switchback_stratified",
-        "cluster_cols": ["time", "city"],
+        "cluster_cols": ["city"],
         "strata_cols": ["day_of_week", "hour_of_day", "city"],
         "target_col": "y",
         "n_simulations": 3,

--- a/tests/splitter/test_switchback_splitter.py
+++ b/tests/splitter/test_switchback_splitter.py
@@ -1,9 +1,6 @@
 import pandas as pd
 import pytest
 
-from cluster_experiments.experiment_analysis import OLSAnalysis
-from cluster_experiments.perturbator import ConstantPerturbator
-from cluster_experiments.power_analysis import PowerAnalysis
 from cluster_experiments.random_splitter import SwitchbackSplitter
 from tests.splitter.conftest import (
     balanced_splitter_parametrize,
@@ -80,16 +77,6 @@ def test_stratified_splitter(splitter, add_cluster_cols, biweekly_df, request):
         assert treatment_assignment.groupby([col, "treatment"]).size().nunique() == 1
 
 
-def test_raise_time_col_not_in_df():
-    with pytest.raises(
-        AssertionError,
-        match="in switchback splitters, time_col must be in cluster_cols",
-    ):
-        sw = SwitchbackSplitter(time_col="time")
-        perturbator = ConstantPerturbator()
-        analysis = OLSAnalysis()
-        _ = PowerAnalysis(
-            splitter=sw,
-            perturbator=perturbator,
-            analysis=analysis,
-        )
+def test_time_in_cluster_cols():
+    sw = SwitchbackSplitter(time_col="time")
+    assert "time" in sw.cluster_cols


### PR DESCRIPTION
If the time_col is not provided as a cluster_col, add it after aggregating to switch length, to enable the assignment of treatment/control