### PR TITLE
feat: add relative mixed perturbator

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ The library offers the following classes:
     * `ConstantPerturbator`: to artificially perturb treated group with constant perturbations
     * `BinaryPerturbator`: to artificially perturb treated group for binary outcomes
     * `RelativePositivePerturbator`: to artificially perturb treated group with relative positive perturbations
+    * `RelativeMixedPerturbator`: to artificially perturb treated group with relative perturbations for positive and negative targets
     * `NormalPerturbator`: to artificially perturb treated group with normal distribution perturbations
     * `BetaRelativePositivePerturbator`: to artificially perturb treated group with relative positive beta distribution perturbations
     * `BetaRelativePerturbator`: to artificially perturb treated group with relative beta distribution perturbations in a specified support interval

--- a/cluster_experiments/__init__.py
+++ b/cluster_experiments/__init__.py
@@ -21,6 +21,7 @@ from cluster_experiments.perturbator import (
     ConstantPerturbator,
     NormalPerturbator,
     Perturbator,
+    RelativeMixedPerturbator,
     RelativePositivePerturbator,
     SegmentedBetaRelativePerturbator,
     UniformPerturbator,
@@ -84,4 +85,5 @@ __all__ = [
     "Dimension",
     "Variant",
     "HypothesisTest",
+    "RelativeMixedPerturbator",
 ]

--- a/cluster_experiments/perturbator.py
+++ b/cluster_experiments/perturbator.py
@@ -757,3 +757,55 @@ class BinaryPerturbator(Perturbator):
         )
         df.loc[idx, self.target_col] = to_target
         return df
+
+
+class RelativeMixedPerturbator(Perturbator):
+    """
+    RelativeMixedPerturbator is a Perturbator that applies a multiplicative effect to the target column
+    of treated instances, modifying their values by a relative factor depending on whether they are positive
+    or negative.
+    """
+
+    def perturbate(
+        self, df: pd.DataFrame, average_effect: Optional[float] = None
+    ) -> pd.DataFrame:
+        """
+        Apply the multiplicative effect to the target column of the treated instances. The effect is calculated
+        as a factor of (1 + effect) for non-negative values, and (1 - effect) for negative values.
+
+        Usage:
+
+        ```python
+        from cluster_experiments.perturbator import RelativeConstantPerturbator
+        import pandas as pd
+        df = pd.DataFrame({"target": [1, 2, 3], "treatment": ["A", "B", "A"]})
+        perturbator = RelativeConstantPerturbator()
+        perturbator.perturbate(df, average_effect=1)
+        ```
+        """
+        df = df.copy().reset_index(drop=True)
+        average_effect = self.get_average_effect(average_effect)
+        df = self.apply_multiplicative_effect(df, average_effect)
+        return df
+
+    def apply_multiplicative_effect(
+        self, df: pd.DataFrame, effect: Union[float, np.ndarray]
+    ) -> pd.DataFrame:
+        """
+        Apply the relative multiplicative effect to the target column, adjusting values based on whether
+        they are positive or negative.
+        """
+        mask = df[self.treatment_col] == self.treatment
+        original_values = df.loc[mask, self.target_col]
+
+        # Calculate new values: apply (1 + effect) for non-negative, (1 - effect) for negative values
+        new_values = np.where(
+            original_values >= 0,
+            original_values * (1 + effect),
+            original_values * (1 - effect),
+        )
+
+        # The round is required to avoid float imprecision
+        df.loc[mask, self.target_col] = np.round(new_values, 2)
+
+        return df

--- a/cluster_experiments/perturbator.py
+++ b/cluster_experiments/perturbator.py
@@ -776,11 +776,11 @@ class RelativeMixedPerturbator(Perturbator):
         Usage:
 
         ```python
-        from cluster_experiments.perturbator import RelativeConstantPerturbator
+        from cluster_experiments.perturbator import RelativeMixedPerturbator
         import pandas as pd
-        df = pd.DataFrame({"target": [1, 2, 3], "treatment": ["A", "B", "A"]})
-        perturbator = RelativeConstantPerturbator()
-        perturbator.perturbate(df, average_effect=1)
+        df = pd.DataFrame({"target": [1, -2, 3], "treatment": ["A", "B", "A"]})
+        perturbator = RelativeMixedPerturbator()
+        perturbator.perturbate(df, average_effect=0.1)
         ```
         """
         df = df.copy().reset_index(drop=True)

--- a/tests/perturbator/conftest.py
+++ b/tests/perturbator/conftest.py
@@ -55,3 +55,13 @@ def generate_clustered_data() -> pd.DataFrame:
         }
     )
     return analysis_df
+
+
+@pytest.fixture
+def continuous_mixed_df():
+    return pd.DataFrame(
+        {
+            "target": [0.5, -50, 50, 0.5],
+            "treatment": ["A", "B", "B", "A"],
+        }
+    )

--- a/tests/perturbator/test_perturbator.py
+++ b/tests/perturbator/test_perturbator.py
@@ -8,6 +8,7 @@ from cluster_experiments.perturbator import (
     BinaryPerturbator,
     ConstantPerturbator,
     NormalPerturbator,
+    RelativeMixedPerturbator,
     RelativePositivePerturbator,
     SegmentedBetaRelativePerturbator,
     UniformPerturbator,
@@ -413,3 +414,20 @@ def test_beta_raises_effect_equals_1(continuous_df):
         match=f"Simulated effect needs to be less than 100%, got {average_effect*100:.1f}%",
     ):
         rp.perturbate(continuous_df, average_effect)
+
+
+@pytest.mark.parametrize(
+    "average_effect, avg_target, perturbator",
+    [
+        (0.1, 5.0, RelativeMixedPerturbator),
+        (-0.1, -5.0, RelativeMixedPerturbator),
+    ],
+)
+def test_relative_mixed_perturbator(
+    average_effect, avg_target, perturbator, continuous_mixed_df
+):
+    up = perturbator(average_effect=average_effect)
+    assert (
+        up.perturbate(continuous_mixed_df).query("treatment == 'B'")["target"].mean()
+        == avg_target
+    )

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -31,6 +31,7 @@ from cluster_experiments import (
     PowerConfig,
     RandomSplitter,
     RatioMetric,
+    RelativeMixedPerturbator,
     RelativePositivePerturbator,
     RepeatedSampler,
     SegmentedBetaRelativePerturbator,
@@ -89,6 +90,7 @@ all_objects = [
     Dimension,
     Variant,
     HypothesisTest,
+    RelativeMixedPerturbator,
 ]
 
 


### PR DESCRIPTION
As per this [issue](https://github.com/david26694/cluster-experiments/issues/182), this PR adds a new type of perturbator to allow a target with mixed signals (positive and negative.)
 