### PR TITLE
feat: Add Variance Reduction to Delta Method and couple it with CUPAC

### DIFF
--- a/cluster_experiments/experiment_analysis.py
+++ b/cluster_experiments/experiment_analysis.py
@@ -1225,7 +1225,6 @@ class DeltaMethodAnalysis(ExperimentAnalysis):
         treatment_col: str = "treatment",
         treatment: str = "B",
         covariates: Optional[List[str]] = None,
-        ratio_covariates: Optional[List[Tuple[str]]] = None,
         hypothesis: str = "two-sided",
     ):
         """
@@ -1239,7 +1238,6 @@ class DeltaMethodAnalysis(ExperimentAnalysis):
             treatment_col: name of the column containing the treatment variable.
             treatment: name of the treatment to use as the treated group.
             covariates: list of columns to use as covariates.
-            ratio_covariates: list of tuples of columns to use as covariates for ratio metrics. First element is the numerator column, second element is the denominator column.
             hypothesis: one of "two-sided", "less", "greater" indicating the alternative hypothesis.
 
             Usage:
@@ -1274,7 +1272,6 @@ class DeltaMethodAnalysis(ExperimentAnalysis):
         self.scale_col = scale_col
         self.cluster_cols = cluster_cols or []
         self.covariates = covariates or []
-        self.ratio_covariates = ratio_covariates or []
 
         if cluster_cols is None:
             raise ValueError(
@@ -1305,11 +1302,6 @@ class DeltaMethodAnalysis(ExperimentAnalysis):
         df = self._transform_ratio_metric(df, numerator, denominator)
         df[f"original_{numerator}_{denominator}"] = df[numerator] / df[denominator]
         self.target_metric = f"{numerator}_{denominator}"
-
-        for numerator, denominator in self.ratio_covariates:
-            df = self._transform_ratio_metric(df, numerator, denominator)
-            df[f"original_{numerator}_{denominator}"] = df[numerator] / df[denominator]
-            self.covariates_delta.append(f"{numerator}_{denominator}")
 
         return df
 
@@ -1420,7 +1412,7 @@ class DeltaMethodAnalysis(ExperimentAnalysis):
         if (self._get_num_clusters(df) < 1000).any():
             self.__warn_small_group_size()
 
-        if self.covariates or self.ratio_covariates:
+        if self.covariates:
             self.__check_data_is_aggregated(df)
             ctrl_mean, treat_mean, ctrl_var, treat_var = self.get_statistics_cuped(df)
         else:

--- a/cluster_experiments/power_analysis.py
+++ b/cluster_experiments/power_analysis.py
@@ -103,6 +103,7 @@ class PowerAnalysis:
         n_simulations: int = 100,
         alpha: float = 0.05,
         features_cupac_model: Optional[List[str]] = None,
+        scale_col: Optional[str] = None,
         seed: Optional[int] = None,
         hypothesis: str = "two-sided",
     ):
@@ -120,6 +121,7 @@ class PowerAnalysis:
         self.cupac_handler = CupacHandler(
             cupac_model=cupac_model,
             target_col=target_col,
+            scale_col=scale_col,
             features_cupac_model=features_cupac_model,
         )
         if seed is not None:

--- a/tests/analysis/test_analysis.py
+++ b/tests/analysis/test_analysis.py
@@ -311,6 +311,7 @@ def test_delta_analysis_aggregation(dates):
 
 
 def test_stats_delta_vs_ols(analysis_ratio_df, experiment_dates):
+    np.random.seed(2024)
     experiment_start_date = min(experiment_dates)
 
     analyser_ols = ClusteredOLSAnalysis(cluster_cols=["user"])
@@ -324,10 +325,10 @@ def test_stats_delta_vs_ols(analysis_ratio_df, experiment_dates):
     SE_delta = analyser_delta.get_standard_error(df)
 
     assert point_estimate_delta == pytest.approx(
-        point_estimate_ols, rel=1e-2
+        point_estimate_ols, rel=1e-1
     ), "Point estimate is not consistent with Clustered OLS"
     assert SE_delta == pytest.approx(
-        SE_ols, rel=1e-2
+        SE_ols, rel=1e-1
     ), "Standard error is not consistent with Clustered OLS"
 
 
@@ -351,7 +352,6 @@ def test_delta_cuped_analysis(analysis_ratio_df, experiment_dates):
         cluster_cols=["user"],
         scale_col="scale",
         covariates=["user_target_means"],
-        ratio_covariates=[("pre_target", "pre_scale")],
     )
 
     assert 0.05 >= analyser.get_pvalue(df) >= 0
@@ -362,8 +362,7 @@ def test_aa_delta_cuped_analysis(dates):
     analyser = DeltaMethodAnalysis(
         cluster_cols=["user"],
         scale_col="scale",
-        covariates=["user_target_means"],
-        ratio_covariates=[("pre_target", "pre_scale")],
+        covariates=["pre_user_target_mean"],
     )
     np.random.seed(2024)
     p_values = []
@@ -376,11 +375,12 @@ def test_aa_delta_cuped_analysis(dates):
         )
 
         data = data.groupby(["user", "treatment"], as_index=False).agg(
-            {"target": "sum", "scale": "sum", "user_target_means": "mean"}
+            {"target": "sum", "scale": "sum"}
         )
         pre_data = pre_data.groupby(["user", "treatment"], as_index=False).agg(
             pre_target=("target", "sum"),
             pre_scale=("scale", "sum"),
+            pre_user_target_mean=("user_target_means", "mean"),
         )
         data = data.merge(pre_data, on=["user", "treatment"])
         p_values.append(analyser.get_pvalue(data))
@@ -390,3 +390,59 @@ def test_aa_delta_cuped_analysis(dates):
     assert positive_rate == pytest.approx(
         0.05, abs=0.01
     ), "P-value A/A calculation is incorrect"
+
+
+def test_stats_delta_cuped_vs_ols(analysis_ratio_df, experiment_dates):
+    np.random.seed(2024)
+
+    experiment_start_date = min(experiment_dates)
+
+    analyser_ols = ClusteredOLSAnalysis(
+        cluster_cols=["user"], covariates=["pre_user_target_mean"]
+    )
+    analyser_delta = DeltaMethodAnalysis(
+        cluster_cols=["user"],
+        scale_col="scale",
+        covariates=["pre_user_target_mean"],
+    )
+
+    df_experiment = analysis_ratio_df.query(f"date >= '{experiment_start_date}'")
+    df_pre_experiment = analysis_ratio_df.query(f"date < '{experiment_start_date}'")
+
+    df_pre_experiment = df_pre_experiment.groupby(
+        ["user", "treatment"], as_index=False
+    ).agg(
+        pre_target=("target", "sum"),
+        pre_scale=("scale", "sum"),
+        pre_user_target_mean=("user_target_means", "mean"),
+    )
+    df = df_experiment.merge(df_pre_experiment, on=["user", "treatment"])
+    # impute nans with mean values
+    df["pre_target"] = df["pre_target"].fillna(df["pre_target"].mean())
+    df["pre_scale"] = df["pre_scale"].fillna(df["pre_scale"].mean())
+    df["pre_user_target_mean"] = df["pre_user_target_mean"].fillna(
+        df["pre_user_target_mean"].mean()
+    )
+
+    df_delta = df.groupby(["user", "treatment"], as_index=False).agg(
+        {
+            "target": "sum",
+            "scale": "sum",
+            "pre_target": "mean",
+            "pre_scale": "mean",
+            "pre_user_target_mean": "mean",
+        }
+    )
+
+    point_estimate_ols = analyser_ols.get_point_estimate(df)
+    point_estimate_delta = analyser_delta.get_point_estimate(df_delta)
+
+    SE_ols = analyser_ols.get_standard_error(df)
+    SE_delta = analyser_delta.get_standard_error(df_delta)
+
+    assert point_estimate_delta == pytest.approx(
+        point_estimate_ols, rel=1e-1
+    ), "Point estimate is not consistent with Clustered OLS"
+    assert SE_delta == pytest.approx(
+        SE_ols, rel=1e-1
+    ), "Standard error is not consistent with Clustered OLS"


### PR DESCRIPTION
CUPED is used with the Delta Method. 
This is intended to be used directly with the Power Analysis so the user is expected to use CUPAC. This simplifies a bit the usage although it is a slight approximation but should work for our implementation. 
Otherwise we have to change how the interface works so we can pass ratio_metrics and normal metrics, which might imply a ton of refactoring and changing how users usually interact with the library.

Please feel free to check it and we can discuss implementation and align on the best way going forward!

![image](https://github.com/user-attachments/assets/51479f2c-359f-40c6-8948-65668f72ab20)
![image](https://github.com/user-attachments/assets/789cfe80-2300-453f-9ce4-8595d61eef45)
<img width="621" alt="Screenshot 2025-03-02 at 20 00 08" src="https://github.com/user-attachments/assets/1173408a-92fb-45ce-810c-3de675358456" />
