### PR TITLE
Fix the covariate mean used to centre the delta-method CUPED correction

### DIFF
--- a/cluster_experiments/experiment_analysis.py
+++ b/cluster_experiments/experiment_analysis.py
@@ -1798,8 +1798,16 @@ class DeltaMethodAnalysis(ExperimentAnalysis):
         is_treatment = df[self.treatment_col] == 1
 
         thetas_dict = self._compute_thetas(df) if self.covariates else None
+        # Scale-weighted mean of each covariate. _correct_target subtracts
+        # theta * (covariate - mean) * scale, so `mean` has to be on the same
+        # scale as the covariate itself. Dividing the covariate sum by the scale
+        # sum instead would be smaller by a factor of the mean scale, leaving a
+        # constant offset in every corrected target. That offset cancels out of
+        # the treatment-control difference, so it does not affect an absolute
+        # effect, but it does not cancel out of a ratio, so it corrupts the
+        # denominator of a relative effect.
         covariates_means = [
-            df[covariate].sum() / df[self.scale_col].sum()
+            (df[covariate] * df[self.scale_col]).sum() / df[self.scale_col].sum()
             for covariate in self.covariates
         ]
 

--- a/cluster_experiments/experiment_analysis.py
+++ b/cluster_experiments/experiment_analysis.py
@@ -205,10 +205,7 @@ class ExperimentAnalysis(ABC):
         print(a)
         ```
         """
-        return (
-            f"{type(self).__name__}: cluster_cols={self.cluster_cols}, "
-            f"target={self.target_col}, treatment={self.treatment}"
-        )
+        return f"{type(self).__name__}: cluster_cols={self.cluster_cols}, target={self.target_col}, treatment={self.treatment}"
 
     def _get_cluster_column(self, df: pd.DataFrame) -> pd.Series:
         """Paste all strings of cluster_cols in one single column"""
@@ -1800,12 +1797,7 @@ class DeltaMethodAnalysis(ExperimentAnalysis):
         thetas_dict = self._compute_thetas(df) if self.covariates else None
         # Scale-weighted mean of each covariate. _correct_target subtracts
         # theta * (covariate - mean) * scale, so `mean` has to be on the same
-        # scale as the covariate itself. Dividing the covariate sum by the scale
-        # sum instead would be smaller by a factor of the mean scale, leaving a
-        # constant offset in every corrected target. That offset cancels out of
-        # the treatment-control difference, so it does not affect an absolute
-        # effect, but it does not cancel out of a ratio, so it corrupts the
-        # denominator of a relative effect.
+        # scale as the covariate itself
         covariates_means = [
             (df[covariate] * df[self.scale_col]).sum() / df[self.scale_col].sum()
             for covariate in self.covariates

--- a/tests/analysis/test_delta_relative.py
+++ b/tests/analysis/test_delta_relative.py
@@ -1162,3 +1162,103 @@ def test_standard_error_curve_is_flat_without_effect_dependence():
         > curved.standard_error_at(0.0)
         > curved.standard_error_at(-0.5)
     )
+
+
+def test_relative_delta_with_covariates_recovers_planted_lift():
+    """
+    A relative effect with CUPED covariates must recover the planted lift, and
+    agree with the same analysis run without covariates.
+
+    The covariate mean used to centre the CUPED correction has to be on the same
+    scale as the covariate. Dividing the covariate sum by the scale sum instead
+    leaves a constant offset in every corrected target. That offset cancels out
+    of the treatment-control difference, so an absolute effect is unharmed, but it
+    does not cancel out of a ratio: it lands in the denominator of the relative
+    lift and inflated it by a factor of the mean scale (~19x here).
+    """
+    n_users, true_relative_lift = 20_000, 0.10
+    rng = np.random.default_rng(3)
+    scale = rng.integers(5, 20, size=n_users).astype(float)
+    base_rate = np.clip(0.30 + rng.normal(0, 0.06, size=n_users), 0.05, 0.95)
+    treatment_flag = rng.integers(0, 2, size=n_users)
+    df = pd.DataFrame(
+        {
+            "user": np.arange(n_users),
+            "scale": scale,
+            "target": rng.binomial(
+                scale.astype(int),
+                np.clip(base_rate * (1 + true_relative_lift * treatment_flag), 0, 1),
+            ).astype(float),
+            "treatment": np.where(treatment_flag == 0, "A", "B"),
+            # covariate on the ratio scale, as the delta-method CUPED expects
+            "pre_rate": base_rate + rng.normal(0, 0.01, size=n_users),
+        }
+    )
+
+    def relative_analysis(covariates):
+        return DeltaMethodAnalysis(
+            cluster_cols=["user"],
+            scale_col="scale",
+            target_col="target",
+            covariates=covariates,
+            relative_effect=True,
+        )
+
+    without = relative_analysis([])
+    with_cuped = relative_analysis(["pre_rate"])
+
+    lift_without = without.get_point_estimate(df)
+    lift_with = with_cuped.get_point_estimate(df)
+
+    # Both must land near the planted lift, and near each other.
+    assert lift_without == pytest.approx(true_relative_lift, rel=0.20)
+    assert lift_with == pytest.approx(true_relative_lift, rel=0.20)
+    assert lift_with == pytest.approx(lift_without, rel=0.05)
+
+    # CUPED must also tighten the relative standard error, not loosen it.
+    assert with_cuped.get_standard_error(df) < without.get_standard_error(df)
+
+
+def test_standard_error_curve_with_covariates():
+    """
+    The standard error curve is well formed for a relative delta analysis with
+    covariates, and mde/power still invert each other exactly.
+    """
+    from cluster_experiments.random_splitter import ClusteredSplitter
+
+    df = _make_ratio_df(
+        n_users=4_000, treatment_effect=0.0, seed=21, with_covariate=True
+    )
+    covariates = ["pre_rate"]
+
+    curve = DeltaMethodAnalysis(
+        cluster_cols=["user"],
+        scale_col="scale",
+        target_col="target",
+        covariates=covariates,
+        relative_effect=True,
+    ).get_standard_error_curve(df)
+
+    assert curve.is_effect_dependent
+    assert curve.std_error > 0
+    # The arms stay independent under CUPED, so the covariance coefficient is
+    # still exactly minus the variance one.
+    assert curve.effect_cov == pytest.approx(-curve.effect_var, rel=1e-12)
+
+    for hypothesis in ["greater", "less"]:
+        pw = NormalPowerAnalysis(
+            analysis=DeltaMethodAnalysis(
+                cluster_cols=["user"],
+                scale_col="scale",
+                target_col="target",
+                covariates=covariates,
+                relative_effect=True,
+                hypothesis=hypothesis,
+            ),
+            splitter=ClusteredSplitter(cluster_cols=["user"]),
+        )
+        mde = pw._mde_from_curve(curve, 0.05, 0.8)
+        achieved = pw._normal_power_calculation(
+            alpha=0.05, se_curve=curve, average_effect=mde
+        )
+        assert achieved == pytest.approx(0.8, abs=1e-12)


### PR DESCRIPTION
## The bug

`_correct_target` subtracts `theta * (covariate - mean) * scale`, so `mean` has to be on the same scale as the covariate. It was computed as the covariate sum over the **scale** sum:

```python
covariates_means = [df[covariate].sum() / df[self.scale_col].sum() ...]
```

That is smaller than the covariate's mean by a factor of the mean scale (`0.0251` vs `0.3002` on the data below, ~12x), leaving a constant offset in every corrected target.

## Why it has been invisible

The offset **cancels out of `treat_mean - ctrl_mean`**, so absolute effects and their CUPED variance reduction are completely unaffected. It does **not** cancel out of a ratio, so it lands in the denominator of the relative lift.

Adding relative effects to the delta method is what turns a latent bug into a live one.

## Evidence

Planted **+10%** relative lift, N=20,000, one covariate on the ratio scale:

| covariate mean | `ctrl_mean` | relative ATE | off by |
|---|---|---|---|
| current `sum(x)/sum(N)` | 0.0176 | **+193.63%** | 19.4x |
| fixed `sum(x*N)/sum(N)` | 0.2967 | +11.52% | 1.15x |
| no covariates (reference) | — | +11.55% | 1.15x |

After the fix, relative-with-covariates agrees with relative-without-covariates to 0.03pp, and both sit within sampling error of the planted 10%. The relative standard error and the MDE were wrong by the same factor.

## Absolute path is untouched

- CUPED variance reduction identical: **10.1%** before and after
- Every absolute-effect case in an `mde` / `power_line` / `mde_time_line` / `mde_rolling_time_line` comparison against `main` is still **bit-identical** (21 analysis x hypothesis cases)

## Tests

Covariates had been covered for the point estimate and the standard error, but never through the standard error curve, the MDE, or power. Adds two tests for that gap.

`test_relative_delta_with_covariates_recovers_planted_lift` fails without the fix (obtained `1.936`, expected `0.1`), so it is not vacuous.

Full suite: **607 passed**.

## Provenance

The bug predates this work. It arrived with the delta-method CUPED feature in `bbc2092` and is present on `main` today; `relative_effect` is only what exposes it.

Based on `MDE-new-ratio-metrics-review` so it stacks with the standard-error-curve work, but it is independent of it and could equally target `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)